### PR TITLE
Provide feedback on missing sensor data

### DIFF
--- a/drivers/ipwebcam/device.js
+++ b/drivers/ipwebcam/device.js
@@ -53,7 +53,18 @@ class IpwebcamDevice extends Homey.Device {
           }
         })
         .catch(error => {
-          this.setUnavailable(Homey.__('Unreachable'));
+		  switch (error)
+		  {
+		    case 'err_sensor_motion':
+			case 'err_sensor_sound':
+			case 'err_sensor_light':
+			case 'err_sensor_battery':
+              this.setUnavailable(Homey.__(error));
+			  break;
+		    default:
+              this.setUnavailable(Homey.__('Unreachable'));
+			  break;
+		  }
           this.pingDevice();
         })
     }, 1000 * interval);

--- a/lib/util.js
+++ b/lib/util.js
@@ -61,28 +61,42 @@ exports.getIpwebcam = function (address, port, username, password) {
       .then(json => {
         var lux = 0;
 
-        if(json.hasOwnProperty("motion_active") && !isEmpty(json.motion_active.data) && json.motion_active.data[0][1][0] == 1) {
-          var motion = true;
-        } else {
-          var motion = false;
-        }
+        if(json.hasOwnProperty("motion_active") &&
+          !isEmpty(json.motion_active.data))
+		{
+          if(json.motion_active.data[0][1][0] == 1)
+          {
+            var motion = true;
+          } else {
+            var motion = false;
+          }
+		} else { return reject('err_sensor_motion'); }
 
-        if(json.hasOwnProperty("sound_event") && !isEmpty(json.sound_event.data) && json.sound_event.data[0][1][0] == 1) {
-          var sound = true;
-        } else {
-          var sound = false;
-        }
+        if(json.hasOwnProperty("sound_event") &&
+          !isEmpty(json.sound_event.data))
+		{
+          if(json.sound_event.data[0][1][0] == 1)
+          {
+            var sound = true;
+          } else {
+            var sound = false;
+          }
+		} else { return reject('err_sensor_sound'); }
 
-        if(json.hasOwnProperty("light") && !isEmpty(json.light.data)) {
+        if(json.hasOwnProperty("light") &&
+          !isEmpty(json.light.data))
+        {
           var lux = json.light.data[0][1][0];
         } else {
-          var lux = 0;
+          return reject('err_sensor_light');
         }
 
-        if(json.hasOwnProperty("battery_level") && !isEmpty(json.battery_level.data)) {
+        if(json.hasOwnProperty("battery_level") &&
+          !isEmpty(json.battery_level.data))
+        {
           var battery = json.battery_level.data[0][1][0];
         } else {
-          var battery = 100;
+          return reject('err_sensor_battery');
         }
 
         var result = {

--- a/locales/en.json
+++ b/locales/en.json
@@ -33,6 +33,10 @@
         "success": "Settings have been saved succesfully."
     },
     "Unreachable": "Unreachable",
+	"err_sensor_motion": "Missing sensor data: motion",
+	"err_sensor_sound": "Missing sensor data: sound",
+	"err_sensor_light": "Missing sensor data: light",
+	"err_sensor_battery": "Missing sensor data: battery",
     "Live Snapshot": "Live Snapshot",
     "This is a test email which confirms your email settings in the Homey IP Webcam App are correct.": "This is a test email which confirms your email settings in the Homey IP Webcam App are correct.",
     "<h1>Homey IP Webcam App</h1><p>This is a test email which confirms your email settings in the Homey IP Webcam App are correct.</p>": "<h1>Homey IP Webcam App</h1><p>This is a test email which confirms your email settings in the Homey IP Webcam App are correct.</p>",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -33,6 +33,10 @@
       "success": "Instellingen zijn succesvol opgeslagen."
     },
     "Unreachable": "Onbereikbaar",
+	"err_sensor_motion": "Sensor data ontbreekt: motion",
+	"err_sensor_sound": "Sensor data ontbreekt: sound",
+	"err_sensor_light": "Sensor data ontbreekt: light",
+	"err_sensor_battery": "Sensor data ontbreekt: battery",
     "Live Snapshot": "Live snapshot",
     "This is a test email which confirms your email settings in the Homey IP Webcam App are correct.": "Dit is een test email die bevestigd dat je instellingen voor email in de Homey IP Webcam App correct zijn.",
     "<h1>Homey IP Webcam App</h1><p>This is a test email which confirms your email settings in the Homey IP Webcam App are correct.</p>": "<h1>Homey IP Webcam App</h1><p>Dit is een test email die bevestigd dat je instellingen voor email in de Homey IP Webcam App correct zijn.</p>",


### PR DESCRIPTION
> Not sure if this is actually useful from a user point of view. If a user has not followed the instructions and enabled the proper data logs in Android IP Webcam they will now get a default value and they might think it's working. Getting an error in these case will force them to fix their configuration. But I'll give it a go and see if I will start getting questions like "your app is not working, it's not updating the values" .. :-)
#3

You're probably right, I've updated the checks to return specific errors, depending on the missing sensor data to give the user feedback on why the connection wasn't successful. You're discretion which version you prefer ;-)