### PR TITLE
Using device class "camera" instead of "sensor"

### DIFF
--- a/app.json
+++ b/app.json
@@ -53,7 +53,7 @@
 				"large": "drivers/ipwebcam/assets/images/large.jpg",
 				"small": "drivers/ipwebcam/assets/images/small.jpg"
 			},
-			"class": "sensor",
+			"class": "camera",
 			"capabilities": [
 				"measure_battery",
 				"alarm_motion",


### PR DESCRIPTION
Not sure what is expected behavior with the app is, but after I installed the app/device I couldn't view the live snapshot in the app. It was more or less behaving as a motion sensor, with actions to send snapshot to an email. 

I was looking for a "live" view of the camera from within the app and ability to use tokens/tags to send snapshots to other actions, e.g. send image to Telegram chat. I saw that the code has implemented tokens but I somehow it didn't show up in the Flow editor. 

With this pull request I'm changing the device class to "camera" instead of "sensor". This solves my two issues (live snapshot view, and token tags are usable).